### PR TITLE
Block Mechanoid corpses from the Compost Bin

### DIFF
--- a/1.3/Defs/CompostBin.xml
+++ b/1.3/Defs/CompostBin.xml
@@ -33,6 +33,9 @@
           <categories>
             <li>Corpses</li>
           </categories>
+          <disallowedCategories>
+            <li>CorpsesMechanoid</li>
+          </disallowedCategories>
           <specialFiltersToAllow>
             <li>AllowRotten</li>
           </specialFiltersToAllow>


### PR DESCRIPTION
You really shouldn't be able to compost a metal robot.